### PR TITLE
feat: serve champion images locally with ddragon CDN fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 help
 /dist
+/public/champions
 
 
 # local env files

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "serve": "vite preview"
+    "serve": "vite preview",
+    "download-champions": "node scripts/download-champions.mjs"
   },
   "dependencies": {
     "pinia": "^2.0.14",

--- a/scripts/download-champions.mjs
+++ b/scripts/download-champions.mjs
@@ -1,0 +1,111 @@
+import https from 'https'
+import http from 'http'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const DDRAGON_VERSION = '12.11.1'
+const CHAMPION_LIST_URL = `https://ddragon.leagueoflegends.com/cdn/${DDRAGON_VERSION}/data/en_US/champion.json`
+const ICON_URL = (id) => `https://ddragon.leagueoflegends.com/cdn/${DDRAGON_VERSION}/img/champion/${id}.png`
+const SPLASH_URL = (id) => `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${id}_0.jpg`
+
+const ICONS_DIR = path.join(__dirname, '../public/champions')
+const SPLASH_DIR = path.join(__dirname, '../public/champions/splash')
+
+function ensureDir(dir) {
+    if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true })
+    }
+}
+
+function downloadFile(url, dest) {
+    return new Promise((resolve, reject) => {
+        if (fs.existsSync(dest)) {
+            resolve('skipped')
+            return
+        }
+        const file = fs.createWriteStream(dest)
+        const client = url.startsWith('https') ? https : http
+        client.get(url, (res) => {
+            if (res.statusCode !== 200) {
+                file.close()
+                fs.unlinkSync(dest)
+                reject(new Error(`HTTP ${res.statusCode} for ${url}`))
+                return
+            }
+            res.pipe(file)
+            file.on('finish', () => file.close(() => resolve('downloaded')))
+        }).on('error', (err) => {
+            file.close()
+            if (fs.existsSync(dest)) fs.unlinkSync(dest)
+            reject(err)
+        })
+    })
+}
+
+async function fetchJson(url) {
+    return new Promise((resolve, reject) => {
+        https.get(url, (res) => {
+            let data = ''
+            res.on('data', chunk => data += chunk)
+            res.on('end', () => {
+                try { resolve(JSON.parse(data)) }
+                catch (e) { reject(e) }
+            })
+        }).on('error', reject)
+    })
+}
+
+async function main() {
+    ensureDir(ICONS_DIR)
+    ensureDir(SPLASH_DIR)
+
+    console.log(`Fetching champion list (version ${DDRAGON_VERSION})...`)
+    const data = await fetchJson(CHAMPION_LIST_URL)
+    const champions = Object.values(data.data)
+    console.log(`${champions.length} champions found.\n`)
+
+    let downloaded = 0
+    let skipped = 0
+    let errors = 0
+
+    for (let i = 0; i < champions.length; i++) {
+        const champ = champions[i]
+        const { id } = champ
+        const progress = `[${i + 1}/${champions.length}]`
+
+        // Icon
+        try {
+            const iconResult = await downloadFile(ICON_URL(id), path.join(ICONS_DIR, `${id}.png`))
+            if (iconResult === 'downloaded') downloaded++
+            else skipped++
+        } catch (e) {
+            console.error(`${progress} ERROR icon ${id}: ${e.message}`)
+            errors++
+        }
+
+        // Splash
+        try {
+            const splashResult = await downloadFile(SPLASH_URL(id), path.join(SPLASH_DIR, `${id}_0.jpg`))
+            if (splashResult === 'downloaded') downloaded++
+            else skipped++
+        } catch (e) {
+            console.error(`${progress} ERROR splash ${id}: ${e.message}`)
+            errors++
+        }
+
+        process.stdout.write(`\r${progress} ${id.padEnd(20)} | downloaded: ${downloaded} | skipped: ${skipped} | errors: ${errors}`)
+    }
+
+    console.log(`\n\nDone!`)
+    console.log(`  Downloaded : ${downloaded}`)
+    console.log(`  Skipped    : ${skipped} (already existed)`)
+    console.log(`  Errors     : ${errors}`)
+    console.log(`\nImages saved to:`)
+    console.log(`  Icons   : public/champions/<ChampId>.png`)
+    console.log(`  Splashes: public/champions/splash/<ChampId>_0.jpg`)
+}
+
+main().catch(console.error)

--- a/src/components/Background.vue
+++ b/src/components/Background.vue
@@ -3,6 +3,7 @@
         <img
             class="absolute w-full h-full image"
             :src="champion && phase == 'pick' ? championStyle : 'https://i.imgur.com/2Qyocz8.png'"
+            @error="onSplashError"
         />
         <!-- <img
       v-else
@@ -24,6 +25,7 @@
 <script lang="ts" setup>
 import { Phase } from "@/types/championSelect.types"
 import { computed, PropType } from "vue"
+import { onSplashError } from "@/utils/championImages"
 
 const props = defineProps({
     champion: String,
@@ -32,8 +34,7 @@ const props = defineProps({
 
 //TODO: find a better way to handle champion background
 const championStyle = computed(
-    () =>
-        `https://fastcdn.mobalytics.gg/assets/lol/images/dd/champions/backgrounds/${props.champion?.toLowerCase()}.jpg`,
+    () => `/champions/splash/${props.champion}_0.jpg`,
 )
 </script>
 <style lang="scss">

--- a/src/components/Bans.vue
+++ b/src/components/Bans.vue
@@ -2,7 +2,7 @@
     <div class="w-full flex justify-center mt-5" :class="{ 'flex-row-reverse': props.side == 'blue' }">
         <div v-for="i in 5" :key="i" class="w-10 aspect-square relative bg-black border-2 border-gray-400 mr-2">
             <div v-if="checkBan(i - 1)">
-                <img :key="i" :src="bans?.[i - 1].image" :alt="bans?.[i - 1].name" />
+                <img :key="i" :src="bans?.[i - 1].image" :alt="bans?.[i - 1].name" @error="onIconError" />
             </div>
             <div class="w-2/3 absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2" v-else>
                 <BanIcon />
@@ -14,6 +14,7 @@
 <script lang="ts" setup>
 import { PropType } from "vue"
 import { Champions, Side } from "@/types/championSelect.types"
+import { onIconError } from "@/utils/championImages"
 import BanIcon from "./icons/BanIcon.vue"
 
 const props = defineProps({

--- a/src/components/ChampionPortrait.vue
+++ b/src/components/ChampionPortrait.vue
@@ -17,6 +17,7 @@
                 :src="champion?.image"
                 :alt="champion?.name"
                 :width="imageSize"
+                @error="onIconError"
             />
             <p class="text-sm text-center" v-if="!hideName">{{ champion?.name }}</p>
             <div
@@ -43,6 +44,7 @@
 import { computed, PropType } from "vue"
 
 import { ChampionPortrait, Phase, Side } from "@/types/championSelect.types"
+import { onIconError } from "@/utils/championImages"
 
 import HoverIcon from "./icons/HoverIcon.vue"
 import BanIcon from "./icons/BanIcon.vue"

--- a/src/components/ChampionsGrid.vue
+++ b/src/components/ChampionsGrid.vue
@@ -10,7 +10,7 @@
                     :disabled="isChampBanned(c.id)"
                     :champion="{
                         name: c.name,
-                        image: `https://fastcdn.mobalytics.gg/assets/lol/images/dd/champions/icons/${c.id.toLowerCase()}.png`,
+                        image: `/champions/${c.id}.png`,
                     }"
                     @click="clickChampion(c.id)"
                 />
@@ -53,13 +53,13 @@ const clickChampion = (champId: string): void => {
 //TODO: Fix name/id confusion around types
 
 const isChampBanned = (name: string): boolean => {
-    return props.bannedChampions.includes(name.toLowerCase())
+    return props.bannedChampions.some(b => b.toLowerCase() === name.toLowerCase())
 }
 
 const banChampion = () => {
     emit("bannedChamp", {
         side: "blue",
-        champ: props.hoveredChampion.toLowerCase(),
+        champ: props.hoveredChampion,
     })
     emit("update:hoveredChampion", "")
 }

--- a/src/store/champions.ts
+++ b/src/store/champions.ts
@@ -38,7 +38,7 @@ export const useChampions = defineStore({
 
         banChampion(side: Side, champ: string): void {
             if (this.bans[side].length < 5) {
-                this.bans[side].push({ name: champ, image: `https://fastcdn.mobalytics.gg/assets/lol/images/dd/champions/icons/${champ}.png` })
+                this.bans[side].push({ name: champ, image: `/champions/${champ}.png` })
             }
         }
 

--- a/src/utils/championImages.ts
+++ b/src/utils/championImages.ts
@@ -1,0 +1,19 @@
+const DDRAGON_VERSION = '12.11.1'
+
+export function onIconError(event: Event) {
+    const img = event.target as HTMLImageElement
+    if (img.src.includes('ddragon')) return
+    const filename = img.src.split('/').pop()
+    if (filename) {
+        img.src = `https://ddragon.leagueoflegends.com/cdn/${DDRAGON_VERSION}/img/champion/${filename}`
+    }
+}
+
+export function onSplashError(event: Event) {
+    const img = event.target as HTMLImageElement
+    if (img.src.includes('ddragon')) return
+    const filename = img.src.split('/').pop()
+    if (filename) {
+        img.src = `https://ddragon.leagueoflegends.com/cdn/img/champion/splash/${filename}`
+    }
+}


### PR DESCRIPTION
- Download script (npm run download-champions) fetches all icons and splashes from ddragon to public/champions/
- Updated all image URLs to use local paths instead of mobalytics CDN
- Added onIconError/onSplashError fallback handlers to load from ddragon if local files are missing
- Fixed champion ID casing for ddragon compatibility (e.g. Ashe not ashe)
- Added /public/champions to .gitignore